### PR TITLE
Dependencies included and fixes.

### DIFF
--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -37,9 +37,7 @@ export default class Gallery extends Component {
 
     constructor (props) {
         super(props);
-        this.state = {
-            imagesDimensions: []
-        };
+
         this.renderPage = this.renderPage.bind(this);
         this.onPageSelected = this.onPageSelected.bind(this);
         this.onPageScrollStateChanged = this.onPageScrollStateChanged.bind(this);

--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -254,7 +254,7 @@ export default class Gallery extends PureComponent {
     }
 
     render () {
-        DEVE && console.log('Gallery render');
+        DEV && console.log('Gallery render');
         let gestureResponder = this.gestureResponder;
 
         let images = this.props.images;

--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { View, Image } from 'react-native';
 import { createResponder } from 'react-native-gesture-responder';
 import TransformableImage from 'react-native-transformable-image';
-import ViewPager from '@ldn0x7dc/react-native-view-pager';
+import ViewPager from './ViewPager';
 
 export default class Gallery extends Component {
 

--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -217,7 +217,6 @@ export default class Gallery extends Component {
     }
 
     renderPage (pageData, pageId, layout) {
-      console.log(`Rendering page: ${pageId}`);
         const { onViewTransformed, onTransformGestureReleased, ...other } = this.props;
         return (
             <TransformableImage

--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -1,14 +1,24 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { View, Image } from 'react-native';
 import { createResponder } from 'react-native-gesture-responder';
 import TransformableImage from './TransformableImage';
 import ViewPager from './ViewPager';
 
-export default class Gallery extends Component {
+const DEV = false;
+
+export default class Gallery extends PureComponent {
 
     static propTypes = {
         ...View.propTypes,
-        images: PropTypes.array,
+        images: PropTypes.arrayOf(PropTypes.shape({
+            source: PropTypes.shape({
+                uri: PropTypes.string.isRequired,
+                dimensions: PropTypes.shape({
+                    width: PropTypes.number,
+                    height: PropTypes.number,
+                }),
+            }),
+        })),
         initialPage: PropTypes.number,
         pageMargin: PropTypes.number,
         onPageSelected: PropTypes.func,
@@ -214,11 +224,10 @@ export default class Gallery extends Component {
         this.props.onPageScroll && this.props.onPageScroll(e);
     }
 
-    renderPage (pageData, pageId, layout) {
-        const { onViewTransformed, onTransformGestureReleased, ...other } = this.props;
+    renderPage (pageData, pageId) {
+        const { onViewTransformed, onTransformGestureReleased } = this.props;
         return (
             <TransformableImage
-              {...other}
               onViewTransformed={((transform) => {
                   onViewTransformed && onViewTransformed(transform, pageId);
               })}
@@ -227,9 +236,7 @@ export default class Gallery extends Component {
               })}
               ref={((ref) => { this.imageRefs.set(pageId, ref); })}
               key={'innerImage#' + pageId}
-              style={{width: layout.width, height: layout.height}}
               source={pageData.source}
-              pixels={ pageData.dimensions || pageData.source.dimensions || {}}
             />
         );
     }
@@ -247,6 +254,7 @@ export default class Gallery extends Component {
     }
 
     render () {
+        DEVE && console.log('Gallery render');
         let gestureResponder = this.gestureResponder;
 
         let images = this.props.images;

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -5,7 +5,7 @@ import { Image } from 'react-native';
 
 import ViewTransformer from 'react-native-view-transformer';
 
-let DEV = true;
+let DEV = false;
 
 export default class TransformableImage extends Component {
 

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,0 +1,195 @@
+'use strict';
+
+import React, { Component, PropTypes } from 'react';
+import { Image } from 'react-native';
+
+import ViewTransformer from 'react-native-view-transformer';
+
+let DEV = true;
+
+export default class TransformableImage extends Component {
+
+  static enableDebug() {
+    DEV = true;
+  }
+
+  static propTypes = {
+    pixels: PropTypes.shape({
+      width: PropTypes.number,
+      height: PropTypes.number,
+    }),
+
+    enableTransform: PropTypes.bool,
+    enableScale: PropTypes.bool,
+    enableTranslate: PropTypes.bool,
+    onTransformGestureReleased: PropTypes.func,
+    onViewTransformed: PropTypes.func,
+    imageComponent: PropTypes.func,
+    resizeMode: PropTypes.string,
+  };
+
+  static defaultProps = {
+    enableTransform: true,
+    enableScale: true,
+    enableTranslate: true,
+    imageComponent: undefined,
+    resizeMode: 'contain',
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      width: 0,
+      height: 0,
+
+      imageLoaded: false,
+      pixels: undefined,
+      keyAcumulator: 1
+    };
+  }
+
+  componentWillMount() {
+    if (!this.props.pixels) {
+      this.getImageSize(this.props.source);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!sameSource(this.props.source, nextProps.source)) {
+      //image source changed, clear last image's pixels info if any
+      this.setState({pixels: undefined, keyAcumulator: this.state.keyAcumulator + 1})
+      this.getImageSize(nextProps.source);
+    }
+  }
+
+  render() {
+    let maxScale = 1;
+    let contentAspectRatio = undefined;
+    let width, height; //pixels
+
+    if (this.props.pixels) {
+      //if provided via props
+      width = this.props.pixels.width;
+      height = this.props.pixels.height;
+    } else if (this.state.pixels) {
+      //if got using Image.getSize()
+      width = this.state.pixels.width;
+      height = this.state.pixels.height;
+    }
+
+    if (width && height) {
+        DEV && console.log(`TransformableImage: (${width}, ${height})`)
+      contentAspectRatio = width / height;
+      if (this.state.width && this.state.height) {
+        maxScale = Math.max(width / this.state.width, height / this.state.height);
+        maxScale = Math.max(1, maxScale);
+      }
+    }
+
+    const imageProps = {
+      ...this.props,
+      style: [this.props.style, {backgroundColor: 'transparent'}],
+      resizeMode: this.props.resizeMode,
+      onLoadStart: this.onLoadStart.bind(this),
+      onLoad: this.onLoad.bind(this),
+      capInsets: {left: 0.1, top: 0.1, right: 0.1, bottom: 0.1},
+    }
+
+    const image = this.props.imageComponent ?
+        this.props.imageComponent(imageProps) :
+        <Image { ...imageProps } />
+
+    return (
+      <ViewTransformer
+        ref='viewTransformer'
+        key={'viewTransformer#' + this.state.keyAccumulator} //when image source changes, we should use a different node to avoid reusing previous transform state
+        enableTransform={this.props.enableTransform && this.state.imageLoaded} //disable transform until image is loaded
+        enableScale={this.props.enableScale}
+        enableTranslate={this.props.enableTranslate}
+        enableResistance={true}
+        onTransformGestureReleased={this.props.onTransformGestureReleased}
+        onViewTransformed={this.props.onViewTransformed}
+        maxScale={maxScale}
+        contentAspectRatio={contentAspectRatio}
+        onLayout={this.onLayout.bind(this)}
+        style={this.props.style}>
+        { image }
+      </ViewTransformer>
+    );
+  }
+
+  onLoadStart(e) {
+    this.props.onLoadStart && this.props.onLoadStart(e);
+    if (this.state.imageLoaded) {
+      this.setState({
+        imageLoaded: false
+      });
+    }
+  }
+
+  onLoad(e) {
+    this.props.onLoad && this.props.onLoad(e);
+    if (!this.state.imageLoaded) {
+      this.setState({
+        imageLoaded: true
+      });
+    }
+  }
+
+  onLayout(e) {
+    let {width, height} = e.nativeEvent.layout;
+    if (this.state.width !== width || this.state.height !== height) {
+      this.setState({
+        width: width,
+        height: height
+      });
+    }
+  }
+
+  getImageSize(source) {
+    if(!source) return;
+
+    DEV && console.log('getImageSize...' + JSON.stringify(source));
+
+    if (typeof Image.getSize === 'function') {
+      if (source && source.uri) {
+        Image.getSize(
+          source.uri,
+          (width, height) => {
+            DEV && console.log('getImageSize...width=' + width + ', height=' + height);
+            if (width && height) {
+              if(this.state.pixels && this.state.pixels.width === width && this.state.pixels.height === height) {
+                //no need to update state
+              } else {
+                this.setState({pixels: {width, height}});
+              }
+            }
+          },
+          (error) => {
+            console.error('getImageSize...error=' + JSON.stringify(error) + ', source=' + JSON.stringify(source));
+          })
+      } else {
+        console.warn('getImageSize...please provide pixels prop for local images');
+      }
+    } else {
+      console.warn('getImageSize...Image.getSize function not available before react-native v0.28');
+    }
+  }
+
+  getViewTransformerInstance() {
+    return this.refs['viewTransformer'];
+  }
+}
+
+function sameSource(source, nextSource) {
+  if (source === nextSource) {
+    return true;
+  }
+  if (source && nextSource) {
+    if (source.uri && nextSource.uri) {
+      return source.uri === nextSource.uri;
+    }
+  }
+  return false;
+}

--- a/library/ViewPager.js
+++ b/library/ViewPager.js
@@ -21,6 +21,8 @@ export default class ViewPager extends Component {
     scrollEnabled: PropTypes.bool,
     renderPage: PropTypes.func,
     pageDataArray: PropTypes.array,
+    initialListSize: PropTypes.number,
+    removeClippedSubviews: PropTypes.bool,
 
     onPageSelected: PropTypes.func,
     onPageScrollStateChanged: PropTypes.func,
@@ -32,6 +34,8 @@ export default class ViewPager extends Component {
     pageMargin: 0,
     scrollEnabled: true,
     pageDataArray: [],
+    initialListSize: 10,
+    removeClippedSubviews: true,
   };
 
   pageCount = 0; //Initialize to avoid undefined error
@@ -132,6 +136,8 @@ export default class ViewPager extends Component {
           dataSource={dataSource}
           renderRow={this.renderRow.bind(this)}
           onLayout={this.onLayout.bind(this)}
+          removeClippedSubviews={ this.props.removeClippedSubviews }
+          initialListSize={ this.props.initialListSize }
         />
       </View>
     );

--- a/library/ViewPager.js
+++ b/library/ViewPager.js
@@ -1,0 +1,299 @@
+import React, { PropTypes, Component } from 'react';
+import {
+  View,
+  ListView,
+  Platform
+} from 'react-native';
+
+import Scroller from 'react-native-scroller';
+import {createResponder} from 'react-native-gesture-responder';
+import TimerMixin from 'react-timer-mixin';
+import reactMixin from 'react-mixin';
+
+const MIN_FLING_VELOCITY = 0.5;
+
+export default class ViewPager extends Component {
+
+  static propTypes = {
+    ...View.propTypes,
+    initialPage: PropTypes.number,
+    pageMargin: PropTypes.number,
+    scrollEnabled: PropTypes.bool,
+    renderPage: PropTypes.func,
+    pageDataArray: PropTypes.array,
+
+    onPageSelected: PropTypes.func,
+    onPageScrollStateChanged: PropTypes.func,
+    onPageScroll: PropTypes.func,
+  };
+
+  static defaultProps = {
+    initialPage: 0,
+    pageMargin: 0,
+    scrollEnabled: true,
+    pageDataArray: [],
+  };
+
+  pageCount = 0; //Initialize to avoid undefined error
+  currentPage = undefined; //Do not initialize to make onPageSelected(0) be dispatched
+  layoutChanged = false;
+  initialPageSettled = false;
+  activeGesture = false;
+  gestureResponder = undefined;
+
+  constructor(props) {
+    super(props);
+
+    const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+    this.state = {
+      width: 0,
+      height: 0,
+      dataSource: ds.cloneWithRows([])
+    }
+
+    this.scroller = new Scroller(true, (dx, dy, scroller) => {
+      if (dx === 0 && dy === 0 && scroller.isFinished()) {
+        if (!this.activeGesture) {
+          this.onPageScrollStateChanged('idle');
+        }
+      } else {
+        const curX = this.scroller.getCurrX();
+        this.refs['innerListView'] && this.refs['innerListView'].scrollTo({x: curX, animated: false});
+
+        let position = Math.floor(curX / (this.state.width + this.props.pageMargin));
+        position = this.validPage(position);
+        let offset = (curX - this.getScrollOffsetOfPage(position)) / (this.state.width + this.props.pageMargin);
+        let fraction = (curX - this.getScrollOffsetOfPage(position) - this.props.pageMargin) / this.state.width;
+        if (fraction < 0) {
+          fraction = 0;
+        }
+        this.props.onPageScroll && this.props.onPageScroll({
+          position, offset, fraction
+        });
+      }
+    });
+  }
+
+  componentWillMount() {
+    this.gestureResponder = createResponder({
+      onStartShouldSetResponder: (evt, gestureState) => true,
+      onResponderGrant: this.onResponderGrant.bind(this),
+      onResponderMove: this.onResponderMove.bind(this),
+      onResponderRelease: this.onResponderRelease.bind(this),
+      onResponderTerminate: this.onResponderRelease.bind(this)
+    });
+  }
+
+  onResponderGrant(evt, gestureState) {
+    this.scroller.forceFinished(true);
+    this.activeGesture = true;
+    this.onPageScrollStateChanged('dragging');
+  }
+
+  onResponderMove(evt, gestureState) {
+    let dx = gestureState.moveX - gestureState.previousMoveX;
+    this.scrollByOffset(dx);
+  }
+
+  onResponderRelease(evt, gestureState, disableSettle) {
+    this.activeGesture = false;
+    if (!disableSettle) {
+      this.settlePage(gestureState.vx);
+    }
+  }
+
+  render() {
+    let dataSource = this.state.dataSource;
+    if (this.state.width && this.state.height) {
+      let list = this.props.pageDataArray;
+      if (!list) {
+        list = [];
+      }
+      dataSource = dataSource.cloneWithRows(list);
+      this.pageCount = list.length;
+    }
+
+    let gestureResponder = this.gestureResponder;
+    if (!this.props.scrollEnabled || this.pageCount <= 0) {
+      gestureResponder = {};
+    }
+
+    return (
+      <View
+        {...this.props}
+        style={[this.props.style, {flex: 1}]}
+        {...gestureResponder}>
+        <ListView
+          style={{flex: 1}}
+          ref='innerListView'
+          scrollEnabled={false}
+          horizontal={true}
+          enableEmptySections={true}
+          dataSource={dataSource}
+          renderRow={this.renderRow.bind(this)}
+          onLayout={this.onLayout.bind(this)}
+        />
+      </View>
+    );
+  }
+
+  renderRow(rowData, sectionID, rowID, highlightRow) {
+    const {width, height} = this.state;
+    let page = this.props.renderPage(rowData, rowID, {width, height});
+
+    let newProps = {
+      ...page.props,
+      ref: page.ref,
+      style: [page.props.style, {
+        width: width,
+        height: height,
+        position: 'relative',
+      }]
+    };
+    const element = React.createElement(page.type, newProps);
+
+    if (this.props.pageMargin > 0 && rowID > 0) {
+      //Do not using margin style to implement pageMargin. The ListView seems to calculate a wrong width for children views with margin.
+      return (
+        <View style={{width: width + this.props.pageMargin, height: height, alignItems: 'flex-end'}}>
+          {element}
+        </View>
+      );
+    } else {
+      return element;
+    }
+  }
+
+  onLayout(e) {
+    let {width, height} = e.nativeEvent.layout;
+    let sizeChanged = this.state.width !== width || this.state.height !== height;
+    if (width && height && sizeChanged) {
+      //if layout changed, create a new DataSource instance to trigger renderRow
+      this.layoutChanged = true;
+      this.setState({
+        width, height,
+        dataSource: (new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})).cloneWithRows([])
+      });
+    }
+  }
+
+  componentDidUpdate() {
+    if (!this.initialPageSettled) {
+      this.initialPageSettled = true;
+      if (Platform.OS === 'ios') {
+        this.scrollToPage(this.props.initialPage, true);
+      } else {
+        //A trick to solve bugs on Android. Delay a little
+        setTimeout(this.scrollToPage.bind(this, this.props.initialPage, true), 0);
+      }
+    } else if (this.layoutChanged) {
+      this.layoutChanged = false;
+      if (typeof this.currentPage === 'number') {
+        if (Platform.OS === 'ios') {
+          this.scrollToPage(this.currentPage, true);
+        } else {
+          //A trick to solve bugs on Android. Delay a little
+          setTimeout(this.scrollToPage.bind(this, this.currentPage, true), 0);
+        }
+      }
+    }
+  }
+
+  settlePage(vx) {
+    if (vx < -MIN_FLING_VELOCITY) {
+      if (this.currentPage < this.pageCount - 1) {
+        this.flingToPage(this.currentPage + 1, vx);
+      } else {
+        this.flingToPage(this.pageCount - 1, vx);
+      }
+    } else if (vx > MIN_FLING_VELOCITY) {
+      if (this.currentPage > 0) {
+        this.flingToPage(this.currentPage - 1, vx);
+      } else {
+        this.flingToPage(0, vx);
+      }
+    } else {
+      let page = this.currentPage;
+      let progress = (this.scroller.getCurrX() - this.getScrollOffsetOfPage(this.currentPage)) / this.state.width;
+      if (progress > 1 / 3) {
+        page += 1;
+      } else if (progress < -1 / 3) {
+        page -= 1;
+      }
+      page = Math.min(this.pageCount - 1, page);
+      page = Math.max(0, page);
+      this.scrollToPage(page);
+    }
+  }
+
+  getScrollOffsetOfPage(page) {
+    return page * (this.state.width + this.props.pageMargin);
+  }
+
+  flingToPage(page, velocityX) {
+    this.onPageScrollStateChanged('settling');
+
+    page = this.validPage(page);
+    this.onPageChanged(page);
+
+    velocityX *= -1000; //per sec
+    const finalX = this.getScrollOffsetOfPage(page);
+    this.scroller.fling(this.scroller.getCurrX(), 0, velocityX, 0, finalX, finalX, 0, 0);
+
+  }
+
+  scrollToPage(page, immediate) {
+    this.onPageScrollStateChanged('settling');
+
+    page = this.validPage(page);
+    this.onPageChanged(page);
+
+    const finalX = this.getScrollOffsetOfPage(page);
+    if (immediate) {
+      this.scroller.startScroll(this.scroller.getCurrX(), 0, finalX - this.scroller.getCurrX(), 0, 0);
+    } else {
+      this.scroller.startScroll(this.scroller.getCurrX(), 0, finalX - this.scroller.getCurrX(), 0, 400);
+    }
+
+  }
+
+  onPageChanged(page) {
+    if (this.currentPage !== page) {
+      this.currentPage = page;
+      this.props.onPageSelected && this.props.onPageSelected(page);
+    }
+  }
+
+  onPageScrollStateChanged(state) {
+    this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(state);
+  }
+
+  scrollByOffset(dx) {
+    this.scroller.startScroll(this.scroller.getCurrX(), 0, -dx, 0, 0);
+  }
+
+  validPage(page) {
+    page = Math.min(this.pageCount - 1, page);
+    page = Math.max(0, page);
+    return page;
+  }
+
+  /**
+   * A helper function to scroll to a specific page in the ViewPager.
+   * @param page
+   * @param immediate If true, the transition between pages will not be animated.
+   */
+  setPage(page, immediate) {
+    this.scrollToPage(page, immediate);
+  }
+
+  getScrollOffsetFromCurrentPage() {
+    return this.scroller.getCurrX() - this.getScrollOffsetOfPage(this.currentPage);
+  }
+}
+
+/**
+ * Keep in mind that if you use ES6 classes for your React components there is no built-in API for mixins. To use TimerMixin with ES6 classes, we recommend react-mixin.
+ * Refer to 'https://facebook.github.io/react-native/docs/timers.html#content'
+ */
+reactMixin(ViewPager.prototype, TimerMixin);

--- a/library/ViewPager.js
+++ b/library/ViewPager.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import {
   View,
   ListView,
@@ -12,7 +12,9 @@ import reactMixin from 'react-mixin';
 
 const MIN_FLING_VELOCITY = 0.5;
 
-export default class ViewPager extends Component {
+const DEV = false;
+
+export default class ViewPager extends PureComponent {
 
   static propTypes = {
     ...View.propTypes,
@@ -144,17 +146,25 @@ export default class ViewPager extends Component {
   }
 
   renderRow(rowData, sectionID, rowID, highlightRow) {
+    DEV && console.log(`ViewPager:renderRow ${rowID}`);
     const {width, height} = this.state;
-    let page = this.props.renderPage(rowData, rowID, {width, height});
+    let page = this.props.renderPage(rowData, rowID);
+
+    const layout = {
+      width: width,
+      height: height,
+      position: 'relative',
+    }
+    const style = page.props.style ?
+    (
+        [page.props.style, layout]
+    )
+    : layout;
 
     let newProps = {
       ...page.props,
       ref: page.ref,
-      style: [page.props.style, {
-        width: width,
-        height: height,
-        position: 'relative',
-      }]
+      style
     };
     const element = React.createElement(page.type, newProps);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/archriss/react-native-image-gallery#readme",
   "dependencies": {
-    "react-native-transformable-image": "0.0.18",
+    "react-native-view-transformer": "0.0.28",
     "react-native-gesture-responder": "0.1.1",
     "react-native-scroller": "0.0.6",
     "react-mixin": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,5 @@
     "react-native-scroller": "0.0.6",
     "react-mixin": "^3.0.5",
     "react-timer-mixin": "^0.13.3"
-  },
-  "peerDependencies": {
-    "react": ">=15.4.0 || ^16.0.0-alpha",
-    "react-native": ">=0.40"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
   "homepage": "https://github.com/archriss/react-native-image-gallery#readme",
   "dependencies": {
     "react-native-transformable-image": "0.0.18",
-    "@ldn0x7dc/react-native-view-pager": "0.0.9",
-    "react-native-gesture-responder": "0.1.1"
+    "react-native-gesture-responder": "0.1.1",
+    "react-native-scroller": "0.0.6",
+    "react-mixin": "^3.0.5",
+    "react-timer-mixin": "^0.13.3"
+  },
+  "peerDependencies": {
+    "react": ">=15.4.0 || ^16.0.0-alpha",
+    "react-native": ">=0.40"
   }
 }


### PR DESCRIPTION
**This is WIP PR**, created to give a early look for changes and things to consider.

First of all, @ldn0x7dc seems to not maintain react-native-gallery and its dependencies made by him, big thanks to him for creating it and maintainers of this repo for taking it over.

Second: All this dependency code should be in a separate libraries for sure like they are now, they provide specific functionality and can be used not only for images stuff. But for simplicity of making things done, ViewPager and TransformableImage was included in react-native-image-gallery code for now. Later it must be stripped to forked repositories or something and maintain separately.
I hope there will be a place somewhere for them with a maintainer.
For now it's not my decision to take them over if someone will think 'why you don't take them' :) 

I moved a code here so I tried to include fixes from other PRs and other bugs I found.

1.
https://github.com/ldn0x7dc/react-native-view-pager/issues/4
https://github.com/ldn0x7dc/react-native-view-pager/issues/3
https://github.com/archriss/react-native-image-gallery/issues/9

I think ScrollView is a something encapsulated in ViewPager and if something is needed to set, it should be exposed as a ViewPager -> Gallery interface, so i added initialListSize (name probably should be different) prop and also removeClippedSubviews which fixed some issues as well for me at least.
What about:
https://github.com/ldn0x7dc/react-native-view-pager/pull/7/commits/279fac124a0c018011a112f9cd7cb07e634e39f9
it's a style for ScrollView and i agree it can be as a separate prop (not included here yet)

2.
For 12 items, my list was rendering them ALL 15 times on start. It was caused by setting imagesLoaded state in Gallery when Image.getSize was invoked. I didn't find a reason to keep track of it in Gallery, what happens for a item should be encapsulated there. For me everything works as was before cause TransformableImage do that already if we have url in source.
Another thing is that we have dimensions for image given from server and getSize should be triggered only when we don't provide them in source, not just if we have url in source.
Let me know if this breaks something but if it does, I'm pretty sure it should be fixed somewhere else.

3.
The same with imagesLoaded state, it was used to display loading indicator for items, but this should be handled by item itself (image component) - read below.

4.
TransformableImage at the end renders Image, we have plenty of reasons to provide render method for it as a prop. When not provided, it will render identically as before.
Changes basically from: https://github.com/novanor/react-native-transformable-image

5.
imagesDimensions was removed from gallery, TransformableImage don't display loading indicator anymore, it should be done in rendered image component. For example react-native-cached-image can do it itself, but anyway, it's few lines of code to make simple component using Image that will render indicator when loading and some error stuff. The point is that this can be done internally, not passing all this onLoad and friends callbacks up. There is one thing that is needed when TransformableImage set enableTransform for ViewTransformer only when image is loaded.

7.
https://github.com/ldn0x7dc/react-native-view-pager/pull/6 included, but not sure about other code that will run after this line, we don't have scroll view to scroll but we send event to onPageScroll. 


It was refactored in short time and still WIP so please let me know if something should work differently, earlier is better :)

Will work on:
- ~~swipe page still invokes render method for all images.~~ DONE
- ~~other unnecessary render cycles to find.~~ DONE (all i found)
- ~~remove unnecessary props passed to children~~ DONE
 
And btw, we need these ALL fixes to make it work and will use our branch for now.
It's impossible without main developer support to make it work other way and use this libraries.

Credits to ALL PRers, but moving code here it was impossible to use all these fixes and improvements from forks.
