### PR TITLE
Fixing initialPage on Android

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -132,6 +132,17 @@ export default class ViewPager extends PureComponent {
         }
     }
 
+    onPageChanged (page) {
+        if (this.currentPage !== page) {
+            this.currentPage = page;
+            this.props.onPageSelected && this.props.onPageSelected(page);
+        }
+    }
+
+    onPageScrollStateChanged (state) {
+        this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(state);
+    }
+
     settlePage (vx) {
         if (vx < -MIN_FLING_VELOCITY) {
             if (this.currentPage < this.props.pageDataArray.length - 1) {
@@ -190,17 +201,6 @@ export default class ViewPager extends PureComponent {
         } else {
             this.scroller.startScroll(this.scroller.getCurrX(), 0, finalX - this.scroller.getCurrX(), 0, 400);
         }
-    }
-
-    onPageChanged (page) {
-        if (this.currentPage !== page) {
-            this.currentPage = page;
-            this.props.onPageSelected && this.props.onPageSelected(page);
-        }
-    }
-
-    onPageScrollStateChanged (state) {
-        this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(state);
     }
 
     scrollByOffset (dx) {

--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -160,9 +160,7 @@ export default class ViewPager extends PureComponent {
     }
 
     getScrollOffsetOfPage (page) {
-        const itemLayout = this.getItemLayout(this.props.pageDataArray, page);
-        console.log(itemLayout.offset);
-        return itemLayout.offset;
+        return this.getItemLayout(this.props.pageDataArray, page).offset;
     }
 
     flingToPage (page, velocityX) {
@@ -293,10 +291,8 @@ export default class ViewPager extends PureComponent {
                   data={pageDataArray}
                   renderItem={this.renderRow}
                   onLayout={this.onLayout}
-                  initialNumToRender={pageDataArray.length}
                   getItemLayout={this.getItemLayout}
                   initialScrollIndex={(this.props.initialPage || undefined)}
-                  extraData={this.state}
               />
             </View>
         );


### PR DESCRIPTION
Changes:
* Use getItemLayout;
* Immediate scroll is done after interactions;
* FlatList is directly called when scrolling and the recordInteraction() method is called;
* The initialScrollIndex prop of FlatList is passed;
* Lifecycle methods are followed by event methods, then come all our methods, then rendering;

Mostly work on #20 