### PR TITLE
v2.1.3

### DIFF
--- a/Demo/package.json
+++ b/Demo/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"react": "16.0.0-alpha.12",
 		"react-native": "0.48.2",
-		"react-native-image-gallery": "2.1.1"
+		"react-native-image-gallery": "2.1.3"
 	},
 	"devDependencies": {
 		"babel-jest": "21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-gallery",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Pure JavaScript image gallery component for iOS and Android",
   "main": "src/Gallery.js",
   "scripts": {

--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -163,6 +163,7 @@ export default class TransformableImage extends PureComponent {
 
         const imageProps = {
             ...this.props,
+            imageLoaded,
             source: image.source,
             style: [style, { backgroundColor: 'transparent' }],
             resizeMode: resizeMode,


### PR DESCRIPTION
* `imageLoaded` from `TransformableImage`'s state is now supplied to the first argument of the `imageComponent` prop, making it easier to display a custom loader in your app.