### PR TITLE
After the scroller is finished, update the scroll position of the fatlist

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -65,13 +65,13 @@ export default class ViewPager extends PureComponent {
 
     createScroller () {
         return new Scroller(true, (dx, dy, scroller) => {
+		const curX = this.scroller.getCurrX();
+                this.refs['innerFlatList'] && this.refs['innerFlatList'].scrollToOffset({ offset: curX, animated: false });
             if (dx === 0 && dy === 0 && scroller.isFinished()) {
                 if (!this.activeGesture) {
                     this.onPageScrollStateChanged('idle');
                 }
             } else {
-                const curX = this.scroller.getCurrX();
-                this.refs['innerFlatList'] && this.refs['innerFlatList'].scrollToOffset({ offset: curX, animated: false });
 
                 let position = Math.floor(curX / (this.state.width + this.props.pageMargin));
                 position = this.validPage(position);


### PR DESCRIPTION
When having multiple images (more than 3) the scrolling to the correct position in the list after rotating the screen is not working correctly on android.

With this fix, after the computation of the postion in the scroller and the scroller being finished, the flatlist will be scrolled to the correct position (currX) of the scroller.

I also filed an issue for this: https://github.com/archriss/react-native-image-gallery/issues/68
