### PR TITLE
expose image load events and bind responders

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -25,7 +25,9 @@ export default class Gallery extends PureComponent {
         removeClippedSubviews: PropTypes.bool,
         imageComponent: PropTypes.func,
         errorComponent: PropTypes.func,
-        flatListProps: PropTypes.object
+        flatListProps: PropTypes.object,
+        onLoad: PropTypes.func,
+        onLoadStart: PropTypes.func
     };
 
     static defaultProps = {
@@ -225,9 +227,23 @@ export default class Gallery extends PureComponent {
     }
 
     renderPage (pageData, pageId) {
-        const { onViewTransformed, onTransformGestureReleased, errorComponent, imageComponent } = this.props;
+        const {
+            onViewTransformed,
+            onTransformGestureReleased,
+            errorComponent,
+            imageComponent,
+            onError,
+            onLoad,
+            onLoadEnd,
+            onLoadStart
+        } = this.props;
+
         return (
             <TransformableImage
+              onError={onError}
+              onLoad={onLoad}
+              onLoadEnd={onLoadEnd}
+              onLoadStart={onLoadStart}
               onViewTransformed={((transform) => {
                   onViewTransformed && onViewTransformed(transform, pageId);
               })}

--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -36,6 +36,7 @@ export default class TransformableImage extends PureComponent {
     constructor (props) {
         super(props);
 
+        this.onError = this.onError.bind(this);
         this.onLayout = this.onLayout.bind(this);
         this.onLoad = this.onLoad.bind(this);
         this.onLoadStart = this.onLoadStart.bind(this);
@@ -73,6 +74,11 @@ export default class TransformableImage extends PureComponent {
 
     componentWillUnmount () {
         this._mounted = false;
+    }
+
+    onError (e) {
+        this.props.onError && this.props.onError(e);
+        this.setState({ error: true });
     }
 
     onLoadStart (e) {
@@ -167,6 +173,7 @@ export default class TransformableImage extends PureComponent {
             source: image.source,
             style: [style, { backgroundColor: 'transparent' }],
             resizeMode: resizeMode,
+            onError: this.onError,
             onLoadStart: this.onLoadStart,
             onLoad: this.onLoad,
             capInsets: { left: 0.1, top: 0.1, right: 0.1, bottom: 0.1 }

--- a/src/libraries/ViewTransformer/index.js
+++ b/src/libraries/ViewTransformer/index.js
@@ -100,10 +100,10 @@ export default class ViewTransformer extends React.Component {
             onStartShouldSetResponder: (evt, gestureState) => true,
             onMoveShouldSetResponderCapture: (evt, gestureState) => true,
             // onMoveShouldSetResponder: this.handleMove,
-            onResponderMove: this.onResponderMove,
-            onResponderGrant: this.onResponderGrant,
-            onResponderRelease: this.onResponderRelease,
-            onResponderTerminate: this.onResponderRelease,
+            onResponderMove: this.onResponderMove.bind(this),
+            onResponderGrant: this.onResponderGrant.bind(this),
+            onResponderRelease: this.onResponderRelease.bind(this),
+            onResponderTerminate: this.onResponderRelease.bind(this),
             onResponderTerminationRequest: (evt, gestureState) => false, // Do not allow parent view to intercept gesture
             onResponderSingleTapConfirmed: (evt, gestureState) => {
                 this.props.onSingleTapConfirmed && this.props.onSingleTapConfirmed();


### PR DESCRIPTION
* re-expose load events through gallery (all props were originally passed through in ldn0x7dc's implementation)
* bind responders so TransformableImage can be used directly, they were resolving to the wrong scope when using outside of Gallery
* show error state in the edge case where the dimensions load but the image does not