### PR TITLE
Added enableZoom prop and fix on adding dynamic images

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -14,6 +14,8 @@ export default class Gallery extends PureComponent {
         ...View.propTypes,
         images: PropTypes.arrayOf(PropTypes.object),
         initialPage: PropTypes.number,
+        enforceInitialPage: PropTypes.bool,
+        maxScale: PropTypes.number,
         scrollViewStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         pageMargin: PropTypes.number,
         onPageSelected: PropTypes.func,
@@ -32,7 +34,9 @@ export default class Gallery extends PureComponent {
     static defaultProps = {
         removeClippedSubviews: true,
         enableZoom: true,
+        enforceInitialPage: false,
         imageComponent: undefined,
+        maxScale: 1,
         scrollViewStyle: {},
         flatListProps: DEFAULT_FLAT_LIST_PROPS
     };
@@ -236,6 +240,7 @@ export default class Gallery extends PureComponent {
         const { onViewTransformed, onTransformGestureReleased, errorComponent, imageComponent } = this.props;
         return (
             <TransformableImage
+              maxScale={this.props.maxScale}
               onViewTransformed={((transform) => {
                   onViewTransformed && onViewTransformed(transform, pageId);
               })}
@@ -286,6 +291,7 @@ export default class Gallery extends PureComponent {
               ref={'galleryViewPager'}
               scrollViewStyle={this.props.scrollViewStyle}
               scrollEnabled={false}
+              enforceInitialPage={this.props.enforceInitialPage}
               renderPage={this.renderPage}
               pageDataArray={images}
               {...gestureResponder}

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -24,12 +24,14 @@ export default class Gallery extends PureComponent {
         onLongPress: PropTypes.func,
         removeClippedSubviews: PropTypes.bool,
         imageComponent: PropTypes.func,
+        enableZoom: PropTypes.bool,
         errorComponent: PropTypes.func,
         flatListProps: PropTypes.object
     };
 
     static defaultProps = {
         removeClippedSubviews: true,
+        enableZoom: true,
         imageComponent: undefined,
         scrollViewStyle: {},
         flatListProps: DEFAULT_FLAT_LIST_PROPS
@@ -125,6 +127,7 @@ export default class Gallery extends PureComponent {
 
         this.imageResponder = {
             onStart: (evt, gestureState) => {
+              if(this.props.enableZoom) {
                 const currentImageTransformer = this.getCurrentImageTransformer();
                 currentImageTransformer && currentImageTransformer.onResponderGrant(evt, gestureState);
                 if (this.props.onLongPress) {
@@ -132,16 +135,21 @@ export default class Gallery extends PureComponent {
                         this.props.onLongPress(gestureState);
                     }, 600);
                 }
+              }
             },
             onMove: (evt, gestureState) => {
+              if(this.props.enableZoom) {
                 const currentImageTransformer = this.getCurrentImageTransformer();
                 currentImageTransformer && currentImageTransformer.onResponderMove(evt, gestureState);
                 clearTimeout(this._longPressTimeout);
+              }
             },
             onEnd: (evt, gestureState) => {
+              if(this.props.enableZoom) {
                 const currentImageTransformer = this.getCurrentImageTransformer();
                 currentImageTransformer && currentImageTransformer.onResponderRelease(evt, gestureState);
                 clearTimeout(this._longPressTimeout);
+              }
             }
         };
     }

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -15,7 +15,6 @@ export default class Gallery extends PureComponent {
         images: PropTypes.arrayOf(PropTypes.object),
         initialPage: PropTypes.number,
         enforceInitialPage: PropTypes.bool,
-        maxScale: PropTypes.number,
         scrollViewStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         pageMargin: PropTypes.number,
         onPageSelected: PropTypes.func,
@@ -36,7 +35,6 @@ export default class Gallery extends PureComponent {
         enableZoom: true,
         enforceInitialPage: false,
         imageComponent: undefined,
-        maxScale: 1,
         scrollViewStyle: {},
         flatListProps: DEFAULT_FLAT_LIST_PROPS
     };
@@ -240,7 +238,6 @@ export default class Gallery extends PureComponent {
         const { onViewTransformed, onTransformGestureReleased, errorComponent, imageComponent } = this.props;
         return (
             <TransformableImage
-              maxScale={this.props.maxScale}
               onViewTransformed={((transform) => {
                   onViewTransformed && onViewTransformed(transform, pageId);
               })}

--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -144,7 +144,7 @@ export default class TransformableImage extends PureComponent {
         const { imageDimensions, viewWidth, viewHeight, error, keyAccumulator, imageLoaded } = this.state;
         const { style, image, imageComponent, resizeMode, enableTransform, enableScale, enableTranslate, onTransformGestureReleased, onViewTransformed } = this.props;
 
-        let maxScale = 1;
+        let maxScale = this.props.maxScale;
         let contentAspectRatio;
         let width, height; // imageDimensions
 

--- a/src/libraries/TransformableImage/index.js
+++ b/src/libraries/TransformableImage/index.js
@@ -144,7 +144,7 @@ export default class TransformableImage extends PureComponent {
         const { imageDimensions, viewWidth, viewHeight, error, keyAccumulator, imageLoaded } = this.state;
         const { style, image, imageComponent, resizeMode, enableTransform, enableScale, enableTranslate, onTransformGestureReleased, onViewTransformed } = this.props;
 
-        let maxScale = this.props.maxScale;
+        let maxScale = 1;
         let contentAspectRatio;
         let width, height; // imageDimensions
 

--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -128,6 +128,9 @@ export default class ViewPager extends PureComponent {
             this.props.pageDataArray.length !== prevProps.pageDataArray.length) {
             this.scrollToPage(this.props.pageDataArray.length, true);
         }
+        if(this.props.enforceInitialPage && this.currentPage !== this.props.initialPage) {
+            this.scrollToPage(this.props.initialPage, true);
+        }
     }
 
     onLayout (e) {

--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -108,7 +108,7 @@ export default class ViewPager extends PureComponent {
 
         const finalX = this.getScrollOffsetOfPage(page);
         this.scroller.startScroll(this.scroller.getCurrX(), 0, finalX - this.scroller.getCurrX(), 0, 0);
-        
+
         requestAnimationFrame(() => {
             // this is here to work around a bug in FlatList, as discussed here
             // https://github.com/facebook/react-native/issues/1831
@@ -263,7 +263,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return index.toString();
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
Added a way to enable or disable zoom with props.
Also fixes an issue when adding dynamic images with the bool enforceInitialPage. When adding dynamic images, it would skip a photo when swiping left.