### PR TITLE
Change imports for better tree shaking

### DIFF
--- a/src/libraries/ViewTransformer/index.js
+++ b/src/libraries/ViewTransformer/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactNative, { View, Animated, Easing, NativeModules } from 'react-native';
+import { View, Animated, Easing, NativeModules, findNodeHandle } from 'react-native';
 import Scroller from '../Scroller';
 import PropTypes from 'prop-types';
 import { createResponder } from '../GestureResponder';
@@ -161,7 +161,7 @@ export default class ViewTransformer extends React.Component {
     }
 
     measureLayout () {
-        let handle = ReactNative.findNodeHandle(this.refs['innerViewRef']);
+        let handle = findNodeHandle(this.refs['innerViewRef']);
         NativeModules.UIManager.measure(handle, (x, y, width, height, pageX, pageY) => {
             if (typeof pageX === 'number' && typeof pageY === 'number') { // avoid undefined values on Android devices
                 if (this.state.pageX !== pageX || this.state.pageY !== pageY) {


### PR DESCRIPTION
I've been doing several experiments with tree shaking and react-native bundles. I had a very simple change to this module to fix using it with a tree shaker. Basically, you want to avoid importing the entire react-native import when possible. The code in ViewTransformer is really only using findNodeHandle along with a few components so I imported it directly. This makes it so the tree shaker code I've been using can avoid bringing in all of react-native.

This is just a slightly modification to the way of importing which shouldn't have any adverse side effects.

Thanks!