### PR TITLE
change keys from a number to a string

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return index.toString();
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
Fixes #92:
> Warning: Failed child content type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer` expected `string`.

Found the answer on this thread:
https://github.com/wonday/react-native-pdf/issues/125