### PR TITLE
fix(warning): Fixed key extractor type

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return String(index);
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
Fixes
> Warning: Failed child content type: Invalid child context virtualizedCell.cellKey of type number supplied to CellRenderer expected string.