### PR TITLE
fix: covert number to string

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return index.toString();
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
index of virtualizedCell.cellKey in FlastList should be a string