### PR TITLE
Solve a warning

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return index.toString();
     }
 
     renderRow ({ item, index }) {

--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,6 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
+        // add toString . Resolve warning info : Invalid child context , expected `string`
         return index.toString();
     }
 


### PR DESCRIPTION
Solve a warning
warning info : Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string` 