### PR TITLE
Keys should always be strings

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return index.toString(); // keys should always be strings
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
I get warnings without this change. This change fixes them.