### PR TITLE
[FIX] - In Viewpager, Flatlist's key needs to be a string

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -260,7 +260,7 @@ export default class ViewPager extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index;
+        return `viewpager_item_${index}`;
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION
Warning is displayed in react native 0.60.3:

> Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.

The warning is removed when replacing the key from a number to a string