### PR TITLE
Fix a warning issue

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -259,9 +259,7 @@ export default class ViewPager extends PureComponent {
         };
     }
 
-    keyExtractor (item, index) {
-        return index;
-    }
+    keyExtractor (item, index) { return index.toString() }
 
     renderRow ({ item, index }) {
         const { width, height } = this.state;


### PR DESCRIPTION
Changed the keyExtractor function in order to fix a warning issue that can be really annoying when building an app with this module