### PR TITLE
#initial page bug fixed on android devices

### DIFF
--- a/src/libraries/ViewPager/index.js
+++ b/src/libraries/ViewPager/index.js
@@ -4,7 +4,8 @@ import {
     FlatList,
     ViewPropTypes,
     InteractionManager,
-    Dimensions
+    Dimensions,
+    Platform
 } from 'react-native';
 import PropTypes from 'prop-types';
 import Scroller from '../Scroller';
@@ -127,6 +128,9 @@ export default class ViewPager extends PureComponent {
         } else if (this.currentPage + 1 >= this.props.pageDataArray.length &&
             this.props.pageDataArray.length !== prevProps.pageDataArray.length) {
             this.scrollToPage(this.props.pageDataArray.length, true);
+        }
+        if (prevProps.initialPage !== this.props.initialPage) {
+            Platform.OS == 'android' && this.scroller.startScroll(this.scroller.getCurrX(), 0, this.getScrollOffsetOfPage(parseInt(this.props.initialPage)) - this.scroller.getCurrX(), 0, 400);
         }
     }
 

--- a/src/libraries/ViewTransformer/index.js
+++ b/src/libraries/ViewTransformer/index.js
@@ -375,7 +375,8 @@ export default class ViewTransformer extends React.Component {
             {
                 toValue: 1,
                 duration: duration,
-                easing: Easing.inOut(Easing.ease)
+                easing: Easing.inOut(Easing.ease),
+                useNativeDriver: true
             }
         ).start();
     }


### PR DESCRIPTION
While implementing this library I faced an issue where `initialPage` prop wasn't working on android devices for some reason `contentOffset` of `FlatList` had no effect on android, I managed to get a workaround for this by triggering manual `startScroll` of `scroller` in `componentDidUpdate` as first time `initialPage` is working fine but it breaks after that.