### PR TITLE
Fix gesture responder binding issues causing errors in `onResponderGrant`.

### DIFF
--- a/src/libraries/ViewTransformer/index.js
+++ b/src/libraries/ViewTransformer/index.js
@@ -100,10 +100,10 @@ export default class ViewTransformer extends React.Component {
             onStartShouldSetResponder: (evt, gestureState) => true,
             onMoveShouldSetResponderCapture: (evt, gestureState) => true,
             // onMoveShouldSetResponder: this.handleMove,
-            onResponderMove: this.onResponderMove,
-            onResponderGrant: this.onResponderGrant,
-            onResponderRelease: this.onResponderRelease,
-            onResponderTerminate: this.onResponderRelease,
+            onResponderMove: this.onResponderMove.bind(this),
+            onResponderGrant: this.onResponderGrant.bind(this),
+            onResponderRelease: this.onResponderRelease.bind(this),
+            onResponderTerminate: this.onResponderRelease.bind(this),
             onResponderTerminationRequest: (evt, gestureState) => false, // Do not allow parent view to intercept gesture
             onResponderSingleTapConfirmed: (evt, gestureState) => {
                 this.props.onSingleTapConfirmed && this.props.onSingleTapConfirmed();


### PR DESCRIPTION
Somehow the context is getting dropped *some of the time*, so that `this` becomes undefined inside `ViewTransformer#onResponderGrant`. Binding the methods to the instance fixes the issue.

We were seeing it inconsistently in production and could never repro the problem ourselves, but the errors went away once we added the binding.

It's unclear how it's only happening some of the time -- usually binding issues will become immediate apparent with React -- so my best guess is there's some detail inside the React Native system where the context can be dropped. 